### PR TITLE
Hue [impala] Patch compat.py to take errors as replace

### DIFF
--- a/src/compat.py
+++ b/src/compat.py
@@ -37,7 +37,7 @@ else:
     from io import BytesIO as BufferIO  # noqa
 
     def binary_to_str(bin_val):
-        return bin_val.decode('utf8')
+        return bin_val.decode('utf8', errors='replace')
 
     def str_to_binary(str_val):
         return bytes(str_val, 'utf8')


### PR DESCRIPTION
```
Python 3.8.8 (v3.8.8:024d8058b0, Feb 19 2021, 08:48:17) 
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> len('引擎'.encode('utf8'))
6
>>> print('引擎'.encode('utf8'))
b'\xe5\xbc\x95\xe6\x93\x8e'
>>> print('引擎'.encode('utf8').decode('utf8'))
引擎
>>> print('引擎'.encode('utf8')[:3].decode('utf8'))
引
>>> print('引擎'.encode('utf8')[:4].decode('utf8'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe6 in position 3: unexpected end of data
>>> print('引擎'.encode('utf8')[:4].decode('utf8', errors='replace'))
引�

To make compat.py decode utf8 to have error tolerance as "replace" 
```